### PR TITLE
Fix: Align profile images in testimonial section

### DIFF
--- a/testimonial.css
+++ b/testimonial.css
@@ -187,11 +187,17 @@ body{
 }
 
 .section_card img {
-    border-radius: 50%;
-    width: 100px;
-    height: 100px;
-    object-fit: cover;
+    display: block; /* Ensures the image is a block-level element */
+    margin: auto; /* Centers the image horizontally */
+    border-radius: 50%; /* Keeps the circular shape */
+    width: 100px; /* Ensures consistent size */
+    height: 100px; /* Ensures consistent size */
+    object-fit: fill; /* Stretches the image to fill the circular frame */
+    object-position: center; /* Centers the content within the frame */
+    border: 2px solid var(--secondary-color); /* Adds a border */
+    transition: border-color 0.3s ease;
 }
+
 
 /* Mobile and tablet styles */
 @media (max-width: 768px) {


### PR DESCRIPTION
Fix profile image alignment issue in the testimonials section

Description:

- Ensured profile images are properly centered within the circular frames.
- Updated CSS to prevent cropping while maintaining consistent scaling.
- Verified responsiveness across different screen sizes.


Earlier Preview:
![image](https://github.com/user-attachments/assets/bef1604c-e5a6-4de9-b2b5-b421d35b97d0)

After Changes:
<img width="1436" alt="Screenshot 2025-01-03 at 3 15 18 PM" src="https://github.com/user-attachments/assets/ee6fd004-ce0d-4e24-a75b-7ae2d88f4ab7" />

