### PR TITLE
Missing Testimonials & Browse Topics in Footer (TOPICS LISTING PAGE)

### DIFF
--- a/topics-listing.html
+++ b/topics-listing.html
@@ -497,19 +497,27 @@
 
                     <ul class="site-footer-links">
                         <li class="site-footer-link-item">
-                            <a href="#" class="site-footer-link">Home</a>
+                            <a href="index.html#section_1" class="site-footer-link">Home</a>
                         </li>
 
                         <li class="site-footer-link-item">
-                            <a href="#" class="site-footer-link">How it works</a>
+                            <a href="index.html#section_2" class="site-footer-link">Browse Topics</a>
                         </li>
 
                         <li class="site-footer-link-item">
-                            <a href="#" class="site-footer-link">FAQs</a>
+                            <a href="index.html#section_3" class="site-footer-link">How it works</a>
                         </li>
 
                         <li class="site-footer-link-item">
-                            <a href="#" class="site-footer-link">Contact</a>
+                            <a href="index.html#section_4" class="site-footer-link">FAQs</a>
+                        </li>
+
+                        <li class="site-footer-link-item">
+                            <a href="index.html#section_5" class="site-footer-link">Testimonials</a>
+                        </li>
+
+                        <li class="site-footer-link-item">
+                            <a href="index.html#section_6" class="site-footer-link">Contact</a>
                         </li>
                     </ul>
                 </div>


### PR DESCRIPTION
fixes: #79 
Added Testimonials & Browse Topics in Footer on Topics listing Page
![image](https://github.com/user-attachments/assets/03bc6043-0a1b-4ea2-9ca0-137b3e5b16dd)
![image](https://github.com/user-attachments/assets/d48726f2-924b-4f2f-a81e-fbb9f8e3df58)
