### PR TITLE
Missing Testimonials & Browse Topics in Footer (TOPICS DETAIL PAGE)

### DIFF
--- a/topics-detail.html
+++ b/topics-detail.html
@@ -439,11 +439,19 @@
                         </li>
 
                         <li class="site-footer-link-item">
+                            <a href="index.html#section_2" class="site-footer-link">Browse Topics</a>
+                        </li>
+
+                        <li class="site-footer-link-item">
                             <a href="index.html#section_3" class="site-footer-link">How it works</a>
                         </li>
 
                         <li class="site-footer-link-item">
                             <a href="index.html#section_4" class="site-footer-link">FAQs</a>
+                        </li>
+
+                        <li class="site-footer-link-item">
+                            <a href="index.html#section_5" class="site-footer-link">Testimonials</a>
                         </li>
 
                         <li class="site-footer-link-item">


### PR DESCRIPTION
fixes: #80 
Added Testimonials and Browse Topics in footer of Topics Detail Page
Reference ss:
![image](https://github.com/user-attachments/assets/e708b9f7-0390-415c-b047-90195a9578c2)
![image](https://github.com/user-attachments/assets/304f0d95-57c4-4d1b-b709-c2137aafc3e3)
